### PR TITLE
BUILD-1194: fix buildah and s2i images for all archs

### DIFF
--- a/clusterBuildStrategy/buildah/buildah.yaml
+++ b/clusterBuildStrategy/buildah/buildah.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   buildSteps:
     - name: build-and-push
-      image: registry.redhat.io/ubi8/buildah:8.8
+      image: registry.redhat.io/ubi8/buildah:8.10-9
       workingDir: $(params.shp-source-root)
       securityContext:
         capabilities:
@@ -168,6 +168,9 @@ spec:
         - $(params.registries-insecure[*])
         - --registries-search
         - $(params.registries-search[*])
+        volumeMounts:
+        - mountPath: /etc/pki/entitlement
+          name: etc-pki-entitlement
       resources:
         limits:
           cpu: "1"
@@ -199,6 +202,10 @@ spec:
       type: string
       default: "vfs"
       # For details see the "--storage-driver" section of https://github.com/containers/buildah/blob/main/docs/buildah.1.md#options
+  volumes:
+    - name: etc-pki-entitlement
+      emptydir: {}
+      overridable: true
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/clusterBuildStrategy/source-to-image/source_to_image.yaml
+++ b/clusterBuildStrategy/source-to-image/source_to_image.yaml
@@ -7,9 +7,12 @@ spec:
   volumes:
     - name: s2i
       emptyDir: {}
+    - name: etc-pki-entitlement
+      emptyDir: {}
+      overridable: true
   buildSteps:
     - name: s2i-generate
-      image: registry.redhat.io/source-to-image/source-to-image-rhel8:v1.3.9
+      image: registry.redhat.io/source-to-image/source-to-image-rhel8:1.4.1
       workingDir: $(params.shp-source-root)
       command: 
         - /usr/local/bin/s2i
@@ -22,8 +25,10 @@ spec:
       volumeMounts:
         - name: s2i
           mountPath: /s2i
+        - name: etc-pki-entitlement
+          mountPath: /etc/pki/entitlement
     - name: buildah
-      image: registry.redhat.io/ubi8/buildah:8.8
+      image: registry.redhat.io/ubi8/buildah:8.10-9
       workingDir: /s2i
       securityContext:
         capabilities:
@@ -134,6 +139,8 @@ spec:
       volumeMounts:
         - name: s2i
           mountPath: /s2i
+        - name: etc-pki-entitlement
+          mountPath: /etc/pki/entitlement
   parameters:
     - name: registries-block
       description: The registries that need to block pull access.


### PR DESCRIPTION
- Fix the image reference so that it has images for all
  architectures.
- fixes BUILD-1194

Signed-off-by: Avinal Kumar <avinal@redhat.com>
