### PR TITLE
CNB 0.12 compliant buildpacks strategy with experimental extender phase

### DIFF
--- a/clusterBuildStrategy/buildpacks/README.md
+++ b/clusterBuildStrategy/buildpacks/README.md
@@ -19,8 +19,7 @@ spec:
   source:
     type: Git
     git: 
-      url: https://github.com/ayushsatyam146/node-example.git
-    contextDir: source-build
+      url: https://github.com/redhat-openshift-builds/samples.git
   strategy:
     name: buildpacks
     kind: ClusterBuildStrategy
@@ -28,27 +27,32 @@ spec:
     atBuildDeletion: true
   paramValues:
     - name: run-image
-      value: paketocommunity/run-ubi-base:latest
+      value: paketobuildpacks/run-ubi8-base:latest
     - name: cnb-builder-image
-      value: paketobuildpacks/builder-jammy-tiny:0.0.176
+      value: paketobuildpacks/builder-jammy-tiny:0.0.344
+    - name: source-subpath
+      value: "buildpacks"
   output:
     image: image-registry.openshift-image-registry.svc:5000/buildpacks-example/taxi-app
 ```
 
 ## Parameters
-| Name               | Type   | Description                                           | Default                                       |
-| ------------------ | ------ | ----------------------------------------------------- | --------------------------------------------- |
-| cnb-platform-api   | string | Platform API Version supported                        | "0.12"                                        |
-| cnb-builder-image  | string | Builder image containing the buildpacks               | ""                                            |
-| cnb-lifecycle-image | string | Image to use when executing Lifecycle phases          | "docker.io/buildpacksio/lifecycle:0.17.0"                                     |
-| run-image          | string | Reference to a run image to use                        | ""                                            |
-| cache-image        | string | Name of the persistent app cache image                 | ""                                            |
-| cache-dir-name     | string | Directory to cache files                               | "cache"                                       |
-| process-type       | string | Default process type to set on the image               | ""                                            |
-| source-subpath     | string | Subpath within the `source` input where the source to build is located | ""                             |
-| env-vars           | array  | Environment variables to set during _build-time_      | []                                            |
-| platform-dir       | string | Name of the platform directory                         | "empty-dir"                                   |
-| user-id            | string | User ID of the builder image user                      | "1001"                                        |
-| group-id           | string | Group ID of the builder image user                     | "1000"                                        |
-| user-home          | string | Absolute path to the user's home directory             | "/tekton/home"                                |
-| cache-pvc-name     | string | Name of the Persistent Volume Claim for cache          | "ws-pvc"                                      |
+
+| Name                      | Type   | Description                                                                      | Default                     |
+|---------------------------|--------|----------------------------------------------------------------------------------|----------------------------|
+| cnb-platform-api         | string | Platform API Version supported                                                  | "0.12"                     |
+| cnb-builder-image         | string | Builder image containing the buildpacks                                         | ""                         |
+| cnb-lifecycle-image       | string | Image to use when executing Lifecycle phases                                    | "buildpacksio/lifecycle:0.20.8" |
+| cnb-log-level             | string | Logging levels                                                                   | "debug"                    |
+| run-image                 | string | Reference to a run image to use                                                 | ""                         |
+| cache-image               | string | Name of the persistent app cache image                                          | ""                         |
+| process-type              | string | Default process type to set on the image                                        | ""                         |
+| source-subpath            | string | Subpath within the `source` input where the source to build is located         | ""                         |
+| env-vars                  | array  | Environment variables to set during _build-time_                                | []                         |
+| platform-dir             | string | Name of the platform directory                                                  | "empty-dir"                |
+| user-id                   | string | User ID of the builder image user                                               | "1001"                     |
+| group-id                  | string | Group ID of the builder image user                                              | "1000"                     |
+| user-home                 | string | Absolute path to the user's home directory                                      | "/tekton/home"             |
+| cache-pvc-name            | string | Name of the Persistent Volume Claim for cache                                   | "ws-pvc"                   |
+| cnb-extender-kind         | string | The kind of image to extend ('build' or 'run')                                  | "build"                    |
+| cnb-extended-dir-exporter | string | Directory of extended layers, passed as -extended flag to the exporter         | "/layers/extended"         |

--- a/clusterBuildStrategy/buildpacks/README.md
+++ b/clusterBuildStrategy/buildpacks/README.md
@@ -8,7 +8,9 @@ $ oc apply -f https://raw.githubusercontent.com/redhat-developer/openshift-build
 ```
 
 ## Usage
-This example uses the buildpacks strategy to build an image, and pushes the built image to OpenShift's internal registry (`output.image`). The following example assumes the OpenShift internal registry is enabled and the `BuildRun` executes in the `buildpacks-example` namespace:
+This example uses the buildpacks strategy to build an image, and pushes the built image to OpenShift's internal registry (`output.image`). This example also has support for "extender mode" which allows you to modify the builder or run image using a Dockerfile. This is useful for installing system dependencies or applying security configurations that standard buildpacks cannot. The Dockerfile is typically provided by a buildpack that supports extensions.
+To use the extender, you set the cnb-extender-kind parameter in your Build resource. The following example assumes the OpenShift internal registry is enabled and the `BuildRun` executes in the `buildpacks-example` namespace:
+
 
 ```yaml
 apiVersion: shipwright.io/v1beta1

--- a/clusterBuildStrategy/buildpacks/buildpacks.yaml
+++ b/clusterBuildStrategy/buildpacks/buildpacks.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: shipwright.io/v1beta1
 kind: ClusterBuildStrategy
 metadata:
@@ -11,25 +10,27 @@ spec:
       emptyDir: {}
     - name: cache-dir
       emptyDir: {}
+    - name: kaniko-work-dir
+      emptyDir: {}
   parameters:
     - name: cnb-platform-api
       description: Platform API Version supported
       default: "0.12"
     - name: cnb-builder-image
-      description: Builder image containing the buildpacks
+      description: Builder image containing the buildpacks. This is also the image the extender will use if kind=build.
       default: ""
     - name: cnb-lifecycle-image
       description: The image to use when executing Lifecycle phases.
-      default: "docker.io/buildpacksio/lifecycle:0.17.0"
+      default: "buildpacksio/lifecycle:0.20.8"
+    - name: cnb-log-level
+      description: Logging level
+      default: "debug"
     - name: run-image
       description: Reference to a run image to use.
       default: ""
     - name: cache-image
       description: The name of the persistent app cache image (if no cache workspace is provided).
       default: ""
-    - name: cache-dir-name
-      description: Directory to cache files
-      default: cache
     - name: process-type
       description: The default process type to set on the image.
       default: ""
@@ -53,9 +54,15 @@ spec:
     - name: user-home
       description: Absolute path to the user's home directory.
       default: /tekton/home
-    - name: cache-pvc-name  # Custom parameter for cache PVC name
+    - name: cache-pvc-name # Custom parameter for cache PVC name, for user reference
       description: Name of the Persistent Volume Claim for cache
       default: "ws-pvc"
+    - name: cnb-extender-kind
+      description: "The kind of image to extend ('build' or 'run'). Passed to the extender."
+      default: "build"
+    - name: cnb-extended-dir-exporter
+      description: "Directory of extended layers, passed as -extended flag to the exporter. Assumes extender outputs here."
+      default: "/layers/extended"
   steps:
     - name: prepare
       image: registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881
@@ -64,23 +71,21 @@ spec:
         - |
           set -e
 
-          # TODO: To be reviewed
-          echo "> Creating the cache directory if it is not empty"
-          if [ ! -d "$DIRECTORY" ]; then
-            echo "> Creating cache: /layers/$(params.cache-dir-name)"
-            mkdir -p /layers/$(params.cache-dir-name)
-            chown -R "$(params.user-id):$(params.group-id)" /layers/$(params.cache-dir-name)
-          fi
-          
           # TODO: To be reviewed as shipwright don't support like Tekton workspaces
-          #if [[ "$(workspaces.cache.bound)" == "true" ]]; then
-          #  echo "> Setting permissions on '$(workspaces.cache.path)'..."
-          #  chown -R "$(params.user-id):$(params.group-id)" "$(workspaces.cache.path)"
-          #fi
+          if [[ "$(workspaces.cache.bound)" == "true" ]]; then
+           echo "> Setting permissions on '$(workspaces.cache.path)'..."
+           chown -R "$(params.user-id):$(params.group-id)" "$(workspaces.cache.path)"
+          fi
 
-          for path in "/tekton/home" "/layers" "$(workspaces.source.path)"; do
-            echo "> Setting permissions on '$path'..."
-            chown -R "$(params.user-id):$(params.group-id)" "$path"
+          # Ensure standard CNB directories have correct ownership
+          # Also ensure /kaniko directory has correct ownership if it's pre-created by volume mount
+          for path in "/tekton/home" "/layers" "$(workspaces.source.path)" "/cache" "/platform" "/kaniko"; do
+            if [ -d "$path" ]; then # Check if directory exists before chown
+              echo "> Setting permissions on '$path'..."
+              chown -R "$(params.user-id):$(params.group-id)" "$path"
+            else
+              echo "> Directory '$path' not found, skipping permissions."
+            fi
           done
 
           echo "> Parsing additional configuration..."
@@ -96,7 +101,7 @@ spec:
           done
 
           echo "> Processing any environment variables..."
-          ENV_DIR="/platform/env"
+          ENV_DIR="/platform/env" # [1]
 
           echo "--> Creating 'env' directory: $ENV_DIR"
           mkdir -p "$ENV_DIR"
@@ -116,19 +121,30 @@ spec:
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
-        - name: empty-dir #name: --> DON'T WORK : $(params.platform-dir)
+        - name: empty-dir # Corresponds to $(params.platform-dir)
           mountPath: /platform
-        - name: cache-dir #name: --> DON'T WORK : $(params.cache-dir-name)
-          mountPath: /tmp/cache
+        - name: cache-dir
+          mountPath: /cache # Standard CNB cache path
+        - name: empty-dir
+          mountPath: /tekton/home
+        - name: kaniko-work-dir # Mounting `/kaniko` in prepare step for permissions
+          mountPath: /kaniko
     - name: analyze
       image: $(params.cnb-lifecycle-image)
       command: ["/cnb/lifecycle/analyzer"]
       args:
-        - "-layers=/layers"
-        - "-run-image=$(params.run-image)"
-        - "-cache-image=$(params.cache-image)"
-        - "-uid=$(params.user-id)"
-        - "-gid=$(params.group-id)"
+        - "-log-level"
+        - "$(params.cnb-log-level)"
+        - "-layers"
+        - "/layers"
+        - "-run-image"
+        - "$(params.run-image)"
+        - "-cache-image"
+        - "$(params.cache-image)"
+        - "-uid"
+        - "$(params.user-id)"
+        - "-gid"
+        - "$(params.group-id)"
         - "$(params.shp-output-image)"
       env:
         - name: CNB_PLATFORM_API
@@ -138,33 +154,50 @@ spec:
           mountPath: /layers
     - name: detect
       image: $(params.cnb-builder-image)
-      imagePullPolicy: Always
       command: [ "/cnb/lifecycle/detector" ]
       args:
-        - "-app=$(workspaces.source.path)/$(params.source-subpath)"
-        - "-group=/layers/group.toml"
-        - "-plan=/layers/plan.toml"
+        - "-log-level"
+        - "$(params.cnb-log-level)"
+        - "-app"
+        - "$(workspaces.source.path)/$(params.source-subpath)"
+        - "-group"
+        - "/layers/group.toml"
+        - "-plan"
+        - "/layers/plan.toml"
+        - "-platform"
+        - "/platform"
+        - "-run"
+        - "/platform/run.toml"
       env:
         - name: CNB_PLATFORM_API
           value: $(params.cnb-platform-api)
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
-        - name: empty-dir # Hard coded the name as substitution do not work: $(params.platform-dir)
+        - name: empty-dir
           mountPath: /platform
         - name: empty-dir
           mountPath: /tekton/home
     - name: restore
       image: $(params.cnb-lifecycle-image)
-      imagePullPolicy: Always
       command: ["/cnb/lifecycle/restorer"]
       args:
-        - "-group=/layers/group.toml"
-        - "-layers=/layers"
-        - "-cache-dir=/layers/$(params.cache-dir-name)"
-        - "-cache-image=$(params.cache-image)"
-        - "-uid=$(params.user-id)"
-        - "-gid=$(params.group-id)"
+        - "-log-level"
+        - "$(params.cnb-log-level)"
+        - "-group"
+        - "/layers/group.toml"
+        - "-layers"
+        - "/layers"
+        - "-cache-dir"
+        - "/cache"
+        - "-cache-image"
+        - "$(params.cache-image)"
+        - "-uid"
+        - "$(params.user-id)"
+        - "-gid"
+        - "$(params.group-id)"
+        - "-build-image"
+        - "$(params.cnb-builder-image)"
       env:
         - name: CNB_PLATFORM_API
           value: $(params.cnb-platform-api)
@@ -172,45 +205,97 @@ spec:
         - name: layers-dir
           mountPath: /layers
         - name: cache-dir
-          mountPath: /tmp/cache #name: --> DON'T WORK : $(params.cache-dir-name)
-    - name: build-and-push
+          mountPath: /cache
+        - name: kaniko-work-dir
+          mountPath: /kaniko
+    - name: extender
       image: $(params.cnb-builder-image)
-      imagePullPolicy: Always
-      securityContext:
-        # runAsUser: 1001 # Won't work : $(params.user-id) -> https://github.com/shipwright-io/build/issues/1354
-        runAsGroup: 1000 # Won't work : $(params.group-id) -> https://github.com/shipwright-io/build/issues/1354
-      command: ["/cnb/lifecycle/builder"]
+      command: ["/cnb/lifecycle/extender"]
       args:
-        - "-app=$(workspaces.source.path)/$(params.source-subpath)"
-        - "-layers=/layers"
-        - "-group=/layers/group.toml"
-        - "-plan=/layers/plan.toml"
+        - "-log-level"
+        - "$(params.cnb-log-level)"
+        - "-kind"
+        - "$(params.cnb-extender-kind)"
+        - "-layers"
+        - "/layers"
+        - "-platform"
+        - "/platform"
+        - "-analyzed"
+        - "/layers/analyzed.toml"
+        - "-generated"
+        - "/layers/generated"
+        - "-plan"
+        - "/layers/plan.toml"
       env:
         - name: CNB_PLATFORM_API
           value: $(params.cnb-platform-api)
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
-        - name: empty-dir # Hard coded the name as substitution do not work: $(params.platform-dir)
+        - name: empty-dir
+          mountPath: /platform
+        - name: cache-dir
+          mountPath: /cache
+        - name: kaniko-work-dir
+          mountPath: /kaniko
+    - name: build-and-push
+      image: $(params.cnb-builder-image)
+      securityContext:
+        runAsGroup: 1000
+      command: ["/cnb/lifecycle/builder"]
+      args:
+        - "-log-level"
+        - "$(params.cnb-log-level)"
+        - "-app"
+        - "$(workspaces.source.path)/$(params.source-subpath)"
+        - "-layers"
+        - "/layers"
+        - "-group"
+        - "/layers/group.toml"
+        - "-plan"
+        - "/layers/plan.toml"
+        - "-platform"
+        - "/platform"
+      env:
+        - name: CNB_PLATFORM_API
+          value: $(params.cnb-platform-api)
+      volumeMounts:
+        - name: layers-dir
+          mountPath: /layers
+        - name: empty-dir
           mountPath: /platform
         - name: empty-dir
           mountPath: /tekton/home
         - name: cache-dir
-          mountPath: /tmp/cache #name: --> DON'T WORK : $(params.cache-dir-name)
+          mountPath: /cache
     - name: export
       image: $(params.cnb-lifecycle-image)
-      imagePullPolicy: Always
       command: ["/cnb/lifecycle/exporter"]
       args:
-        - "-app=$(workspaces.source.path)/$(params.source-subpath)"
-        - "-layers=/layers"
-        - "-group=/layers/group.toml"
-        - "-cache-dir=/layers/$(params.cache-dir-name)"
-        - "-cache-image=$(params.cache-image)"
-        - "-report=/layers/report.toml"
-        - "-process-type=$(params.process-type)"
-        - "-uid=$(params.user-id)"
-        - "-gid=$(params.group-id)"
+        - "-log-level"
+        - "$(params.cnb-log-level)"
+        - "-app"
+        - "$(workspaces.source.path)/$(params.source-subpath)"
+        - "-layers"
+        - "/layers"
+        - "-group"
+        - "/layers/group.toml"
+        - "-cache-dir"
+        - "/cache"
+        - "-cache-image"
+        - "$(params.cache-image)"
+        - "-report"
+        - "/layers/report.toml"
+        - "-project-metadata"
+        - "/platform/project-metadata.toml"
+        - "-process-type"
+        - "$(params.process-type)"
+        - "-uid"
+        - "$(params.user-id)"
+        - "-gid"
+        - "$(params.group-id)"
+        - "-extended"
+        - "$(params.cnb-extended-dir-exporter)"
         - "$(params.shp-output-image)"
       env:
         - name: CNB_PLATFORM_API
@@ -219,7 +304,9 @@ spec:
         - name: layers-dir
           mountPath: /layers
         - name: cache-dir
-          mountPath: /tmp/cache #name: --> DON'T WORK : $(params.cache-dir-name)
+          mountPath: /cache
+        - name: empty-dir
+          mountPath: /platform
     - name: results
       image: registry.access.redhat.com/ubi8/ubi:8.8-1067.1698056881
       args:


### PR DESCRIPTION
The new buildpacks strategy ensures all the below points:

- Has all mandatory build lifecycle phases for CNB 0.12 (analyzer, detector, restorer, builder, exporter) and an optional extender phase.
- Volumes: layers-dir (/layers), empty-dir (/platform, /tekton/home), cache-dir (/cache) meet requirements.
- Appropriate cache configuration since `cache-dir` (/cache) is used in restore and export. `cache-image` used in analyzer, restore, and export. Support for filesystem (/cache) or image-based caching.
- Support for extender(optional) phase

